### PR TITLE
Drop fallback modes and add compatibility screen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+File Organizer is a show-case application whose sole purpose is to demonstrate Apple Intelligence (on-device Foundation Models) in a real-world workflow.
+• The app will not fall back to rule-based heuristics if the model is unavailable.
+• Any feature or code path that assumes “AI disabled” should be removed.
+• Future work (Fast/Thorough speed modes, richer metadata extraction, etc.) must keep this AI-only contract intact.
+
+No rule-based fallback; extension logic removed as of PR-X.
+
+NOTE: Tutorial screen will explain how to enable Apple Intelligence.
+For now this is a placeholder; app may sit idle on incompatible Macs.
+
+TODO (next PR): add SpeedMode (thorough, fast) and token-budget guard
+– thorough: roll-up at 3 500 tokens
+– fast    : hard reset at 2 000 tokens (env SPEED_MODE=fast)

--- a/FileOrganizer/ContentView.swift
+++ b/FileOrganizer/ContentView.swift
@@ -233,7 +233,7 @@ struct ContentView: View {
                             }
                             .accessibilityIdentifier("organizeButton")            // ← NEW
                             .buttonStyle(.borderedProminent)
-                            .disabled(appState.selectedDirectory == nil || fileProcessor.isProcessing)
+                            .disabled(appState.selectedDirectory == nil || fileProcessor.isProcessing || !foundationModelsManager.isAvailable)
                             .controlSize(.large)
                         }
                         .padding(32)

--- a/FileOrganizer/Core/FileProcessor.swift
+++ b/FileOrganizer/Core/FileProcessor.swift
@@ -76,20 +76,9 @@ class FileProcessor: ObservableObject {
                     var updated = file
                     switch mode {
                     case .aiIntelligent:
-                        if foundationModelsManager.isAvailable {
-                            do {
-                                updated.analysisResult = try await analyzeFileWithAI(file)
-                            } catch {
-                                print("AI analysis failed for \(file.name): \(error)")
-                                updated.analysisResult = createFallbackAnalysis(for: file)
-                            }
-                        } else {
-                            updated.analysisResult = createFallbackAnalysis(for: file)
-                        }
+                        updated.analysisResult = try await analyzeFileWithAI(file)
                     case .byDate:
                         updated.analysisResult = createDateBasedAnalysis(for: file)
-                    case .byType:
-                        updated.analysisResult = createTypeBasedAnalysis(for: file)
                     }
 
                     if let meta = updated.analysisResult {
@@ -260,19 +249,6 @@ class FileProcessor: ObservableObject {
     
     // MARK: - Fallback Analysis Methods
     
-    private func createFallbackAnalysis(for fileItem: FileItem) -> FileAnalysisResult {
-        let category = determineCategoryFromExtension(fileItem.fileExtension)
-        
-        return FileAnalysisResult(
-            category: category,
-            subcategory: nil,
-            suggestedName: fileItem.name,
-            description: "Organized by file type",
-            tags: [fileItem.fileExtension],
-            confidence: 0.7
-        )
-    }
-    
     private func createDateBasedAnalysis(for fileItem: FileItem) -> FileAnalysisResult {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy"
@@ -289,44 +265,6 @@ class FileProcessor: ObservableObject {
             tags: ["date-organized"],
             confidence: 1.0
         )
-    }
-    
-    private func createTypeBasedAnalysis(for fileItem: FileItem) -> FileAnalysisResult {
-        let category = determineCategoryFromExtension(fileItem.fileExtension)
-        
-        return FileAnalysisResult(
-            category: category,
-            subcategory: fileItem.fileExtension.uppercased(),
-            suggestedName: fileItem.name,
-            description: "Organized by file type",
-            tags: [fileItem.fileExtension],
-            confidence: 1.0
-        )
-    }
-    
-    private func determineCategoryFromExtension(_ extension: String) -> String {
-        let ext = `extension`.lowercased()
-        
-        switch ext {
-        case "jpg", "jpeg", "png", "gif", "bmp", "tiff", "heic", "webp":
-            return "Images"
-        case "pdf", "doc", "docx", "txt", "rtf", "md", "pages":
-            return "Documents"
-        case "xls", "xlsx", "csv", "numbers":
-            return "Spreadsheets"
-        case "ppt", "pptx", "key":
-            return "Presentations"
-        case "mp3", "wav", "aac", "m4a", "flac", "ogg":
-            return "Audio"
-        case "mp4", "mov", "avi", "mkv", "wmv", "m4v":
-            return "Videos"
-        case "zip", "rar", "7z", "tar", "gz":
-            return "Archives"
-        case "app", "dmg", "pkg":
-            return "Applications"
-        default:
-            return "Other"
-        }
     }
     
     // MARK: - Organization Planning

--- a/FileOrganizer/Core/FoundationModelsManager.swift
+++ b/FileOrganizer/Core/FoundationModelsManager.swift
@@ -137,24 +137,6 @@ class FoundationModelsManager: ObservableObject {
         )
     }
     
-    func createFallbackAnalysis(fileName: String, fileType: String) -> FileAnalysisResult {
-        let category = determineCategoryFromFileType(fileType)
-        
-        return FileAnalysisResult(
-            category: category,
-            subcategory: nil,
-            suggestedName: fileName,
-            description: "File type: \(fileType)",
-            tags: [fileType],
-            confidence: 0.3
-        )
-    }
-    
-    func determineCategoryFromFileType(_ fileType: String) -> String {
-        // Minimal fallback - don't do algorithmic categorization
-        // The whole point is to use AI, not file extensions
-        return "Uncategorized"
-    }
     
     enum FoundationModelsError: Error {
         case sessionNotAvailable

--- a/FileOrganizer/FileOrganizerApp.swift
+++ b/FileOrganizer/FileOrganizerApp.swift
@@ -19,18 +19,27 @@ struct FileOrganizerApp: App {
     
     var body: some Scene {
         WindowGroup {
-            ContentView()
-                .environmentObject(appState)
-                .environmentObject(foundationModelsManager)
-                // ↓↓↓ add this line ↓↓↓
-            .environment(\.testFixtureFolder,
-                          ProcessInfo.processInfo.environment["FIXTURE_PATH"])
-            // ↑↑↑ add this line ↑↑↑
-                .onAppear {
-                    Task {
-                        await foundationModelsManager.initialize()
+            if foundationModelsManager.isAvailable {
+                ContentView()
+                    .environmentObject(appState)
+                    .environmentObject(foundationModelsManager)
+                    .environment(\.testFixtureFolder,
+                                ProcessInfo.processInfo.environment["FIXTURE_PATH"])
+                    .onAppear {
+                        Task {
+                            await foundationModelsManager.initialize()
+                        }
                     }
-                }
+            } else {
+                presentDemoScreen()
+                    .environmentObject(appState)
+                    .environmentObject(foundationModelsManager)
+                    .onAppear {
+                        Task {
+                            await foundationModelsManager.initialize()
+                        }
+                    }
+            }
         }
         .windowStyle(.hiddenTitleBar)
         .windowToolbarStyle(.unified)
@@ -41,6 +50,13 @@ struct FileOrganizerApp: App {
                 .environmentObject(appState)
                 .environmentObject(foundationModelsManager)
         }
+    }
+
+    private func presentDemoScreen() -> some View {
+        // NOTE: Tutorial screen will explain how to enable Apple Intelligence.
+        // For now this is a placeholder; app may sit idle on incompatible Macs.
+        Text("Apple Intelligence not available on this Mac.")
+            .padding()
     }
 }
 

--- a/FileOrganizer/Models/FileAnalysisResult.swift
+++ b/FileOrganizer/Models/FileAnalysisResult.swift
@@ -147,7 +147,6 @@ struct AppSettings: @preconcurrency Codable {
 enum SortingMode: String, CaseIterable, Codable {
     case aiIntelligent = "AI Intelligent"
     case byDate = "By Date"
-    case byType = "By Type"
     
     var description: String {
         switch self {
@@ -155,8 +154,6 @@ enum SortingMode: String, CaseIterable, Codable {
             return "Uses Apple Intelligence to analyze file content and create semantic categories for organizing"
         case .byDate:
             return "Organizes files by modification date in year/month structure"
-        case .byType:
-            return "Groups files by file type (Images, Documents, Videos, etc.)"
         }
     }
     
@@ -166,8 +163,6 @@ enum SortingMode: String, CaseIterable, Codable {
             return "brain.head.profile"
         case .byDate:
             return "calendar"
-        case .byType:
-            return "doc.on.doc"
         }
     }
 }

--- a/FileOrganizer/SessionPool.swift
+++ b/FileOrganizer/SessionPool.swift
@@ -23,6 +23,9 @@ actor SessionPool<T: LanguageModelSessionProtocol> {
     /// Borrow a hot session; waits if all are busy.
     func acquire() async throws -> T {
         while idle.isEmpty { try await Task.sleep(nanoseconds: 2_000_000) }
+        // TODO (next PR): add SpeedMode (thorough, fast) and token-budget guard
+        // – thorough: roll-up at 3 500 tokens
+        // – fast    : hard reset at 2 000 tokens (env SPEED_MODE=fast)
         let s = idle.removeFirst()
         try await s.resetContext()          // ← add
         inUse.insert(ObjectIdentifier(s))


### PR DESCRIPTION
## Summary
- state the project mission in `AGENTS.md`
- remove extension-based fallback logic
- show a placeholder screen when Apple Intelligence isn't available
- disable the Organize Files button when the model isn't ready
- document upcoming token guard work

## Testing
- `swift --version`
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68548023f250832591f3f31fe77f2b70