### PR TITLE
Rename SortingMode description property

### DIFF
--- a/FileOrganizer/Models/FileAnalysisResult.swift
+++ b/FileOrganizer/Models/FileAnalysisResult.swift
@@ -147,7 +147,7 @@ enum SortingMode: String, Codable {
     case aiIntelligent = "AI Intelligent"
 
     /// Human-readable description for the sole sorting mode.
-    static let description = "Uses Apple Intelligence to analyze file content and create semantic categories for organizing"
+    static let humanReadableDescription = "Uses Apple Intelligence to analyze file content and create semantic categories for organizing"
 
     var icon: String { "brain.head.profile" }
 }


### PR DESCRIPTION
## Summary
- rename `SortingMode.description` to `humanReadableDescription`

## Testing
- `xcodebuild -list -project FileOrganizer.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854e48cfb648325963fcaa7a397fd08