### PR TITLE
Fix LiquidGlass compile error

### DIFF
--- a/FileOrganizer/Views/LiquidGlass.swift
+++ b/FileOrganizer/Views/LiquidGlass.swift
@@ -9,9 +9,17 @@ extension View {
     func liquidGlassBackground(cornerRadius: CGFloat = 12) -> some View {
         self
             .padding()
-            .background(.ultraThinMaterial,
-                        in: RoundedRectangle(cornerRadius: cornerRadius,
-                                             style: .continuous))
-            .glassBackgroundEffect()
+            .background(
+                .ultraThinMaterial,
+                in: RoundedRectangle(
+                    cornerRadius: cornerRadius,
+                    style: .continuous
+                )
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .stroke(Color.white.opacity(0.15))
+                    .blendMode(.overlay)
+            )
     }
 }


### PR DESCRIPTION
## Summary
- remove usage of unavailable `glassBackgroundEffect` modifier
- recreate effect using overlay stroke

## Testing
- `xcodebuild -project FileOrganizer.xcodeproj -scheme FileOrganizer build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854fb6147d483258bb0ae4eafcd927d