### PR TITLE
Add shims for missing AppIntents types

### DIFF
--- a/FileOrganizer/Models/IntentShims.swift
+++ b/FileOrganizer/Models/IntentShims.swift
@@ -1,0 +1,21 @@
+#if canImport(AppIntents)
+import AppIntents
+#else
+public struct DataEncoder {
+    private var buffer = Data()
+    public mutating func encode(_ data: Data) throws {
+        buffer = data
+    }
+    public func encodedData() -> Data { buffer }
+}
+
+public struct DataDecoder {
+    private var buffer: Data
+    public init(data: Data) { self.buffer = data }
+    public mutating func decode(_ type: Data.Type) throws -> Data {
+        return buffer
+    }
+}
+
+public protocol IntentValue: Codable {}
+#endif


### PR DESCRIPTION
## Summary
- add conditional shims for `DataEncoder`, `DataDecoder`, and `IntentValue`

## Testing
- `swift test --disable-sandbox` *(fails: Package.swift not found)*

------
https://chatgpt.com/codex/tasks/task_e_685507440800832587ba7f69c28cbb7e