### PR TITLE
Fix AppIntents build issues

### DIFF
--- a/FileOrganizer/Intents/OrganizeFilesIntent.swift
+++ b/FileOrganizer/Intents/OrganizeFilesIntent.swift
@@ -3,9 +3,7 @@ import AppIntents
 import SwiftUI
 
 @available(macOS 26.0, *)
-@MainActor
-
-struct OrganizeFilesIntent: @MainActor AppIntent {
+struct OrganizeFilesIntent: AppIntent {
     static var title: LocalizedStringResource = "Organize Files"
     static var description = IntentDescription("Organize files in a directory using Apple Intelligence")
 
@@ -18,7 +16,9 @@ struct OrganizeFilesIntent: @MainActor AppIntent {
         await manager.initialize()
         let processor = FileProcessor(foundationModelsManager: manager)
         let result = try await processor.processDirectory(directory, isDryRun: true)
-        appState.addToHistory(result)
+        await MainActor.run {
+            appState.addToHistory(result)
+        }
         return .result(
             value: result,
             snippetIntent: OrganizationSnippetIntent(result: result)
@@ -27,8 +27,7 @@ struct OrganizeFilesIntent: @MainActor AppIntent {
 }
 
 @available(macOS 26.0, *)
-@MainActor
-struct OrganizationSnippetIntent: @MainActor SnippetIntent {
+struct OrganizationSnippetIntent: SnippetIntent {
     static var title: LocalizedStringResource = "Organization Results"
 
     @Parameter
@@ -86,8 +85,7 @@ struct OrganizationResultSnippetView: View {
 }
 
 @available(macOS 26.0, *)
-@MainActor
-struct ViewInAppIntent: @MainActor AppIntent {
+struct ViewInAppIntent: AppIntent {
     static var title: LocalizedStringResource = "Open App"
 
     func perform() async throws -> some IntentResult {

--- a/FileOrganizer/Models/FileAnalysisResult.swift
+++ b/FileOrganizer/Models/FileAnalysisResult.swift
@@ -39,7 +39,7 @@ struct FileAnalysisResult: @preconcurrency Codable, Identifiable {
 }
 
 
-struct OrganizationResult: Identifiable, @preconcurrency Codable, Hashable, IntentValue {
+struct OrganizationResult: Identifiable, @preconcurrency Codable, Hashable, Sendable, IntentValue {
     let id: UUID
     let timestamp: Date
     let sourceDirectory: String


### PR DESCRIPTION
## Summary
- remove `@MainActor` isolation from intents
- store history on the main actor
- mark `OrganizationResult` as `Sendable`

## Testing
- `xcodebuild -list` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68550cc40cd88325b7dc1b00fd2d3030