### PR TITLE
Fix AppIntent actor isolation

### DIFF
--- a/FileOrganizer/Intents/OrganizeFilesIntent.swift
+++ b/FileOrganizer/Intents/OrganizeFilesIntent.swift
@@ -3,15 +3,15 @@ import AppIntents
 import SwiftUI
 
 @available(macOS 26.0, *)
-@MainActor
 
-struct OrganizeFilesIntent: @MainActor AppIntent {
+struct OrganizeFilesIntent: AppIntent {
     static var title: LocalizedStringResource = "Organize Files"
     static var description = IntentDescription("Organize files in a directory using Apple Intelligence")
 
     @Parameter(title: "Directory")
     var directory: URL
 
+    @MainActor
     func perform() async throws -> some ReturnsValue<OrganizationResult> & ShowsSnippetIntent {
         let appState = AppState()
         let manager  = FoundationModelsManager()
@@ -27,13 +27,13 @@ struct OrganizeFilesIntent: @MainActor AppIntent {
 }
 
 @available(macOS 26.0, *)
-@MainActor
-struct OrganizationSnippetIntent: @MainActor SnippetIntent {
+struct OrganizationSnippetIntent: SnippetIntent {
     static var title: LocalizedStringResource = "Organization Results"
 
     @Parameter
     var result: OrganizationResult
 
+    @MainActor
     func perform() async throws -> some IntentResult & ShowsSnippetView {
         .result(view: OrganizationResultSnippetView(result: result))
     }
@@ -86,10 +86,10 @@ struct OrganizationResultSnippetView: View {
 }
 
 @available(macOS 26.0, *)
-@MainActor
-struct ViewInAppIntent: @MainActor AppIntent {
+struct ViewInAppIntent: AppIntent {
     static var title: LocalizedStringResource = "Open App"
 
+    @MainActor
     func perform() async throws -> some IntentResult {
         .result()
     }


### PR DESCRIPTION
## Summary
- remove `@MainActor` from AppIntent and SnippetIntent structures
- apply `@MainActor` only on `perform()` methods

## Testing
- `xcodebuild -scheme FileOrganizer build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68550daba0b08325bc3213fa917199d3