### PR TITLE
Remove MainActor from OrganizationSnippetIntent

### DIFF
--- a/FileOrganizer/Intents/OrganizeFilesIntent.swift
+++ b/FileOrganizer/Intents/OrganizeFilesIntent.swift
@@ -27,12 +27,15 @@ struct OrganizeFilesIntent: @MainActor AppIntent {
 }
 
 @available(macOS 26.0, *)
-@MainActor
-struct OrganizationSnippetIntent: @MainActor SnippetIntent {
+struct OrganizationSnippetIntent: SnippetIntent {
     static var title: LocalizedStringResource = "Organization Results"
 
     @Parameter
     var result: OrganizationResult
+
+    init(result: OrganizationResult) {
+        self.result = result
+    }
 
     func perform() async throws -> some IntentResult & ShowsSnippetView {
         .result(view: OrganizationResultSnippetView(result: result))


### PR DESCRIPTION
## Summary
- drop `@MainActor` from `OrganizationSnippetIntent`
- add memberwise initializer so `OrganizationSnippetIntent(result:)` still compiles

## Testing
- `swiftc -parse -target x86_64-apple-macosx13 FileOrganizer/Intents/OrganizeFilesIntent.swift`

------
https://chatgpt.com/codex/tasks/task_e_68550db0e5308325887ff1b2d54262b0