### PR TITLE
Add MainActor annotation to OrganizeFilesIntent.perform

### DIFF
--- a/FileOrganizer/Intents/OrganizeFilesIntent.swift
+++ b/FileOrganizer/Intents/OrganizeFilesIntent.swift
@@ -10,6 +10,7 @@ struct OrganizeFilesIntent: AppIntent {
     @Parameter(title: "Directory")
     var directory: URL
 
+    @MainActor
     func perform() async throws -> some ReturnsValue<OrganizationResult> & ShowsSnippetIntent {
         let appState = AppState()
         let manager  = FoundationModelsManager()


### PR DESCRIPTION
## Summary
- mark `OrganizeFilesIntent.perform()` with `@MainActor`

## Testing
- `swiftc FileOrganizer/Intents/OrganizeFilesIntent.swift -typecheck` *(fails: no such module 'AppIntents')*

------
https://chatgpt.com/codex/tasks/task_e_68550db522508325915010c3b59fe922