### PR TITLE
Remove date-based organization option

### DIFF
--- a/FileOrganizer/Models/FileAnalysisResult.swift
+++ b/FileOrganizer/Models/FileAnalysisResult.swift
@@ -140,7 +140,6 @@ struct AppSettings: @preconcurrency Codable {
     enum OrganizationStrategy: String, CaseIterable, Codable {
         case createSubfolders = "Create Subfolders"
         case flatStructure = "Flat Structure"
-        case dateHierarchy = "Date Hierarchy"
         
         var description: String {
             switch self {
@@ -148,8 +147,6 @@ struct AppSettings: @preconcurrency Codable {
                 return "Create category subfolders"
             case .flatStructure:
                 return "Keep files in same directory with renamed files"
-            case .dateHierarchy:
-                return "Organize by year/month/day structure"
             }
         }
     }


### PR DESCRIPTION
## Summary
- drop the obsolete `.dateHierarchy` case from `OrganizationStrategy`

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -project FileSorter.xcodeproj -scheme FileSorter build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68550f65b0a88325a36e9f55caf12fe9