### PR TITLE
Remove deprecated dry-run mode

### DIFF
--- a/FileOrganizer/ContentView.swift
+++ b/FileOrganizer/ContentView.swift
@@ -113,18 +113,7 @@ struct ContentView: View {
 
                     
                     Divider()
-                    
-                    // Dry Run Toggle
-                    VStack(alignment: .leading, spacing: 8) {
-                        Toggle("Dry Run Mode", isOn: $appState.isDryRun)
-                            .font(.headline)
-                        
-                        Text("Preview changes without moving files")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                    .padding(.horizontal)
-                    
+
                     Spacer()
                     
                     // Navigation Buttons
@@ -311,8 +300,7 @@ struct ContentView: View {
         Task {
             do {
                 let result = try await fileProcessor.processDirectory(
-                    directory,
-                    isDryRun: appState.isDryRun
+                    directory
                 )
                 
                 appState.lastOrganizationResult = result

--- a/FileOrganizer/Core/FileProcessor.swift
+++ b/FileOrganizer/Core/FileProcessor.swift
@@ -32,8 +32,7 @@ class FileProcessor {
     }
     
     // MARK: - Main Processing Functions
-    func processDirectory(_ directoryURL: URL,
-                          isDryRun: Bool = true) async throws -> OrganizationResult {
+    func processDirectory(_ directoryURL: URL) async throws -> OrganizationResult {
 
         // ── Security-scoped URL bookkeeping ───────────────────────────────
         guard let bookmarkData = UserDefaults.standard.data(forKey: "selectedFolderBookmark") else {
@@ -121,7 +120,7 @@ class FileProcessor {
         currentStatus = "Executing organization..."
         progress      = 0.9
 
-        let execResult = try await executeOrganization(plan: plan, isDryRun: isDryRun)
+        let execResult = try await executeOrganization(plan: plan)
 
         progress      = 1
         currentStatus = "Complete"
@@ -144,7 +143,6 @@ class FileProcessor {
             filesProcessed    : total,
             filesOrganized    : execResult.filesOrganized,
             categoriesCreated : execResult.categoriesCreated,
-            isDryRun          : isDryRun,
             duration          : Date().timeIntervalSince(startTime)
         )
     }
@@ -283,8 +281,7 @@ class FileProcessor {
         return OrganizationPlan(
             sourceDirectory: sourceDirectory,
             targetDirectory: targetDirectory,
-            operations: operations,
-            isDryRun: true
+            operations: operations
         )
     }
 
@@ -306,33 +303,24 @@ class FileProcessor {
     
     // MARK: - Organization Execution
     
-    private func executeOrganization(plan: OrganizationPlan, isDryRun: Bool) async throws -> (filesOrganized: Int, categoriesCreated: [String]) {
+    private func executeOrganization(plan: OrganizationPlan) async throws -> (filesOrganized: Int, categoriesCreated: [String]) {
         var filesOrganized: Int? = nil
         var categoriesCreated: Set<String> = []
-        
-        if !isDryRun {
-            // Create target directory
-            try fileManager.createDirectory(at: plan.targetDirectory, withIntermediateDirectories: true)
-        }
+        // Create target directory
+        try fileManager.createDirectory(at: plan.targetDirectory, withIntermediateDirectories: true)
         
         for operation in plan.operations {
             switch operation.operation {
             case .createDirectory:
-                if !isDryRun {
-                    try fileManager.createDirectory(at: operation.targetURL, withIntermediateDirectories: true)
-                }
+                try fileManager.createDirectory(at: operation.targetURL, withIntermediateDirectories: true)
                 categoriesCreated.insert(operation.targetCategory)
-                
+
             case .move:
-                if !isDryRun {
-                    try fileManager.moveItem(at: operation.sourceURL, to: operation.targetURL)
-                }
+                try fileManager.moveItem(at: operation.sourceURL, to: operation.targetURL)
                 filesOrganized = (filesOrganized ?? 0) + 1
-                
+
             case .copy:
-                if !isDryRun {
-                    try fileManager.copyItem(at: operation.sourceURL, to: operation.targetURL)
-                }
+                try fileManager.copyItem(at: operation.sourceURL, to: operation.targetURL)
                 filesOrganized = (filesOrganized ?? 0) + 1
             }
         }

--- a/FileOrganizer/FileOrganizerApp.swift
+++ b/FileOrganizer/FileOrganizerApp.swift
@@ -72,8 +72,7 @@ class AppState: ObservableObject {
     var processingStatus = ""
     var lastOrganizationResult: OrganizationResult?
     var organizationHistory: [OrganizationResult] = []
-    var isDryRun = true
-    
+
     func addToHistory(_ result: OrganizationResult) {
         organizationHistory.insert(result, at: 0)
         if organizationHistory.count > 50 {

--- a/FileOrganizer/Intents/OrganizeFilesIntent.swift
+++ b/FileOrganizer/Intents/OrganizeFilesIntent.swift
@@ -17,7 +17,7 @@ struct OrganizeFilesIntent: AppIntent {
         let manager  = FoundationModelsManager()
         await manager.initialize()
         let processor = FileProcessor(foundationModelsManager: manager)
-        let result = try await processor.processDirectory(directory, isDryRun: true)
+        let result = try await processor.processDirectory(directory)
         await MainActor.run {
             appState.addToHistory(result)
         }

--- a/FileOrganizer/Models/FileAnalysisResult.swift
+++ b/FileOrganizer/Models/FileAnalysisResult.swift
@@ -50,11 +50,10 @@ public struct OrganizationResult: Identifiable, @preconcurrency Codable, Hashabl
     let filesProcessed: Int
     let filesOrganized: Int
     let categoriesCreated: [String]
-    let isDryRun: Bool
     let duration: TimeInterval
     
     
-    init(sourceDirectory: String, targetDirectory: String, mode: String, filesProcessed: Int, filesOrganized: Int, categoriesCreated: [String], isDryRun: Bool, duration: TimeInterval) {
+    init(sourceDirectory: String, targetDirectory: String, mode: String, filesProcessed: Int, filesOrganized: Int, categoriesCreated: [String], duration: TimeInterval) {
         self.id = UUID()
         self.timestamp = Date()
         self.sourceDirectory = sourceDirectory
@@ -63,13 +62,11 @@ public struct OrganizationResult: Identifiable, @preconcurrency Codable, Hashabl
         self.filesProcessed = filesProcessed
         self.filesOrganized = filesOrganized
         self.categoriesCreated = categoriesCreated  // Fix: assign categoriesCreated
-        self.isDryRun = isDryRun
         self.duration = duration
     }
     
     var summary: String {
-        let action = isDryRun ? "Would organize" : "Organized"
-        return "\(action) \(filesOrganized)/\(filesProcessed) files into \(categoriesCreated.count) categories"
+        return "Organized \(filesOrganized)/\(filesProcessed) files into \(categoriesCreated.count) categories"
     }
     
     // MARK: - IntentValue conformance
@@ -108,8 +105,7 @@ struct OrganizationPlan {
     let sourceDirectory: URL
     let targetDirectory: URL
     let operations: [FileOperation]
-    let isDryRun: Bool
-    
+
     var summary: String {
         let categories = Set(operations.map { $0.targetCategory }).count
         return "Plan: Move \(operations.count) files into \(categories) categories"
@@ -132,7 +128,6 @@ struct FileOperation {
 // MARK: - Settings Models
 
 struct AppSettings: @preconcurrency Codable {
-    var enableDryRunByDefault = true
     var maxFilesPerBatch = 100
     var enableProgressNotifications = true
     var organizationStrategy: OrganizationStrategy = .createSubfolders

--- a/FileOrganizer/Views/HistoryView.swift
+++ b/FileOrganizer/Views/HistoryView.swift
@@ -76,8 +76,8 @@ struct HistoryRowView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack {
-                Image(systemName: result.isDryRun ? "eye" : "checkmark.circle.fill")
-                    .foregroundColor(result.isDryRun ? .orange : .green)
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundColor(.green)
                 Text(result.timestamp, style: .relative)
                     .font(.caption)
                     .foregroundColor(.secondary)
@@ -113,19 +113,9 @@ struct HistoryDetailView: View {
                 // Header
                 VStack(alignment: .leading, spacing: 8) {
                     HStack {
-                        Image(systemName: result.isDryRun ? "eye" : "checkmark.circle.fill")
-                            .foregroundColor(result.isDryRun ? .orange : .green)
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(.green)
                         Spacer()
-                        if result.isDryRun {
-                            Text("DRY RUN")
-                                .font(.caption)
-                                .fontWeight(.bold)
-                                .padding(.horizontal, 8)
-                                .padding(.vertical, 4)
-                                .background(Color.orange.opacity(0.2))
-                                .foregroundColor(.orange)
-                                .cornerRadius(4)
-                        }
                     }
                     
                     Text(result.timestamp.formatted())

--- a/FileOrganizer/Views/SettingsView.swift
+++ b/FileOrganizer/Views/SettingsView.swift
@@ -21,8 +21,6 @@ struct SettingsView: View {
         NavigationView {
             Form {
                 Section("General") {
-                    Toggle("Enable Dry Run by Default", isOn: $settings.enableDryRunByDefault)
-                    
                     Stepper("Max Files per Batch: \(settings.maxFilesPerBatch)",
                            value: $settings.maxFilesPerBatch,
                            in: 10...1000,
@@ -140,9 +138,6 @@ struct SettingsView: View {
     private func saveSettings() {
         do {
             try metadataStore.saveSettings(settings)
-            
-            // Apply settings to app state
-            appState.isDryRun = settings.enableDryRunByDefault
             
         } catch {
             print("Failed to save settings: \(error)")


### PR DESCRIPTION
## Summary
- drop `isDryRun` flag from organization models
- clean up processor logic to always perform file moves
- update intent, views and app state for removal
- simplify settings view

## Testing
- `xcodebuild -project FileOrganizer.xcodeproj -scheme FileOrganizer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68550ff828808325a8be7d43c8d3cad3