### PR TITLE
Use stable SHA256 hashing for analysis metadata

### DIFF
--- a/FileOrganizer/Services/MetadataStore.swift
+++ b/FileOrganizer/Services/MetadataStore.swift
@@ -9,6 +9,7 @@
 import Foundation
 import SwiftUI
 import Combine
+import CryptoKit
 
 @available(macOS 26.0, *)
 @MainActor
@@ -40,8 +41,13 @@ class MetadataStore: ObservableObject {
     
     // MARK: - Analysis Results Storage
     
+    private func stableHash(_ input: String) -> String {
+        let digest = SHA256.hash(data: Data(input.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
     func saveAnalysisResults(_ results: [String: FileAnalysisResult], for directoryPath: String) throws {
-        let directoryHash = directoryPath.hash
+        let directoryHash = stableHash(directoryPath)
         let metadataFile = metadataDirectory.appendingPathComponent("analysis_\(directoryHash).json")
         
         let data = try encoder.encode(results)
@@ -49,7 +55,7 @@ class MetadataStore: ObservableObject {
     }
     
     func loadAnalysisResults(for directoryPath: String) throws -> [String: FileAnalysisResult]? {
-        let directoryHash = directoryPath.hash
+        let directoryHash = stableHash(directoryPath)
         let metadataFile = metadataDirectory.appendingPathComponent("analysis_\(directoryHash).json")
         
         guard fileManager.fileExists(atPath: metadataFile.path) else {


### PR DESCRIPTION
## Summary
- generate a stable directory hash using SHA256
- use the stable hash when saving and loading analysis results

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68556bbf21408325ba98c51b25dc8a4d